### PR TITLE
listener parallelism

### DIFF
--- a/src/main/java/edu/tamu/app/observer/AbstractDocumentListener.java
+++ b/src/main/java/edu/tamu/app/observer/AbstractDocumentListener.java
@@ -27,16 +27,16 @@ public abstract class AbstractDocumentListener extends AbstractFileListener {
 
     protected static final Map<String, List<String>> pendingResources = new ConcurrentHashMap<String, List<String>>();
 
-    protected static final ExecutorService executor = Executors.newFixedThreadPool(10);
+    protected static final ExecutorService executor = Executors.newFixedThreadPool(1);
 
     @Autowired
     private ProjectRepo projectRepo;
 
     @Autowired
-    protected DocumentFactory documentFactory;
+    protected DocumentRepo documentRepo;
 
     @Autowired
-    protected DocumentRepo documentRepo;
+    protected DocumentFactory documentFactory;
 
     public AbstractDocumentListener(String root, String folder) {
         super(root, folder);

--- a/src/main/java/edu/tamu/app/observer/AbstractDocumentListener.java
+++ b/src/main/java/edu/tamu/app/observer/AbstractDocumentListener.java
@@ -110,7 +110,7 @@ public abstract class AbstractDocumentListener extends AbstractFileListener {
         pendingResources.put(documentName, new ArrayList<String>());
     }
 
-    protected Document processPendingResources(Document document) {
+    protected Document processResources(Document document, File directory) {
         String documentName = document.getName();
         for (String resourcePath : pendingResources.get(documentName)) {
             document = documentFactory.addResource(document, new File(resourcePath));
@@ -124,7 +124,7 @@ public abstract class AbstractDocumentListener extends AbstractFileListener {
             Document document = null;
             try {
                 document = documentFactory.createDocument(directory);
-                document = processPendingResources(document);
+                document = processResources(document, directory);
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/src/main/java/edu/tamu/app/observer/HeadlessDocumentListener.java
+++ b/src/main/java/edu/tamu/app/observer/HeadlessDocumentListener.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,13 +30,6 @@ public class HeadlessDocumentListener extends AbstractDocumentListener {
     @Value("${app.document.create.wait}")
     private int documentCreationWait;
 
-    @Value("${app.document.publish.concurrency:5}")
-    private int publishConcurrency;
-
-    private static final List<Document> publishQueue = new CopyOnWriteArrayList<Document>();
-
-    private static final AtomicInteger publishing = new AtomicInteger(0);
-
     public HeadlessDocumentListener(String root, String folder) {
         super(root, folder);
     }
@@ -48,11 +39,11 @@ public class HeadlessDocumentListener extends AbstractDocumentListener {
         return CompletableFuture.supplyAsync(() -> {
             Document document = null;
             try {
-                initializePendingResources(directory.getName());
                 waitOnDirectory(directory);
                 document = documentFactory.createDocument(directory);
                 document = processPendingResources(document);
                 document = applyDefaultValues(document);
+                logger.info("Document created: " + document.getName());
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -63,7 +54,6 @@ public class HeadlessDocumentListener extends AbstractDocumentListener {
     @Override
     protected void createdDocumentCallback(Document document) {
         if (document != null) {
-            logger.info("Document created: " + document.getName());
             publishToRepositories(document);
         } else {
             logger.warn("Unable to create document!");
@@ -103,37 +93,15 @@ public class HeadlessDocumentListener extends AbstractDocumentListener {
     }
 
     private void publishToRepositories(Document document) {
-
-        logger.info("Attempting to publish documnet: " + document.getName());
-
-        logger.info("Current concurrency: " + publishing.get());
-
-        if (publishing.get() <= publishConcurrency) {
-            publishing.incrementAndGet();
-
-            for (ProjectRepository repository : document.getProject().getRepositories()) {
-                try {
-                    document = ((Repository) projectServiceRegistry.getService(repository.getName())).push(document);
-                } catch (IOException e) {
-                    logger.error("Exception thrown attempting to push to " + repository.getName() + "!", e);
-                    e.printStackTrace();
-                }
+        logger.info("Attempting to publish document: " + document.getName());
+        for (ProjectRepository repository : document.getProject().getRepositories()) {
+            try {
+                ((Repository) projectServiceRegistry.getService(repository.getName())).push(document);
+            } catch (IOException e) {
+                logger.error("Exception thrown attempting to push to " + repository.getName() + "!", e);
+                e.printStackTrace();
             }
-
-            publishing.decrementAndGet();
-
-            if (publishQueue.size() > 0) {
-                Document queuedDocument = publishQueue.get(0);
-                publishQueue.remove(0);
-                logger.info("Remaining in queue: " + publishQueue.size());
-                publishToRepositories(queuedDocument);
-            }
-
-        } else {
-            logger.info("Queueing document: " + document.getName());
-            publishQueue.add(document);
         }
-
     }
 
 }

--- a/src/main/java/edu/tamu/app/service/authority/CSVAuthority.java
+++ b/src/main/java/edu/tamu/app/service/authority/CSVAuthority.java
@@ -105,7 +105,7 @@ public class CSVAuthority implements Authority {
             logger.info("Preparing to process CSV records using identifier field " + getIdentifier());
             csvParser.getRecords().forEach(record -> {
                 String filename = record.get(getIdentifier());
-                logger.info("Processing record " + filename);
+                logger.debug("Processing record " + filename);
                 if (filename != null) {
                     currentRecords.put(filename, record);
                 } else {

--- a/src/main/java/edu/tamu/app/service/repository/FedoraPCDMRepository.java
+++ b/src/main/java/edu/tamu/app/service/repository/FedoraPCDMRepository.java
@@ -26,7 +26,13 @@ public class FedoraPCDMRepository extends AbstractFedoraRepository {
     private Tika tika;
 
     // @formatter:off
-    private List<String> jpeg2000MimeTypes = Arrays.asList(new String[] { "image/jp2", "image/j2k", "image/jpx", "image/jpm", "image/jpeg2000" });
+    private List<String> jpeg2000MimeTypes = Arrays.asList(new String[] {
+        "image/jp2",
+        "image/j2k",
+        "image/jpx",
+        "image/jpm",
+        "image/jpeg2000"
+    });
     // @formatter:on
 
     private String membersEndpoint = "members";


### PR DESCRIPTION
Removed most concurrency from listeners. Provide executor service with a single thread to perform a single completable future at a time. This starts up the create document process without blocking the listeners inherited listening for files created. New document folders created starts up the create document buts waits in line for the thread pool to have an available thread. The adding of files within that folder still occurs and creates resources asynchronous to the document create.

There may still be a race condition that has been a possibility since having resources become an entity. When the document directory becomes quiescent all the files have been copied, but not all the resources have been created. This presents a race condition.

It appears to be working with this pull request. I would like to have four use cases confirmed before this merge. Headless standard ingest publishing to fedora, headless standard ingest pushing to Archivematica, normal standard ingest, and normal SAF ingest.

There will be continued work to address the concerns of performance and difficulty of parallelism within the listeners. 

The Fedora PCDM push presents a problem withs it creation of the two top level containers. If the first few documents are attempted to be created concurrently, it starts a transaction for each with each creating the top to containers. Upon commit each one tries to create the top level documents and the duplicates get a file system like bracket notation appended to the slug.

There is also a known constraint of concurrently pushing to Fedora of not able to open many concurrent transactions.
