### PR TITLE
[D01294] Can invoke publish for a document that is already pending publication

### DIFF
--- a/src/main/java/edu/tamu/app/controller/DocumentController.java
+++ b/src/main/java/edu/tamu/app/controller/DocumentController.java
@@ -169,6 +169,10 @@ public class DocumentController {
     public ApiResponse push(@PathVariable String projectName, @PathVariable String documentName) {
         Document document = documentRepo.findByProjectNameAndName(projectName, documentName);
 
+        if (document.getStatus().equalsIgnoreCase("pending")) {
+            return new ApiResponse(ERROR, "Cannot publish because document is already pending publication.");
+        }
+
         for (ProjectRepository repository : document.getProject().getRepositories()) {
             try {
                 document = ((Destination) projectServiceRegistry.getService(repository.getName())).push(document);

--- a/src/main/java/edu/tamu/app/model/Document.java
+++ b/src/main/java/edu/tamu/app/model/Document.java
@@ -41,6 +41,9 @@ public class Document extends BaseEntity {
     @Column(nullable = true)
     private String path;
 
+    @Column(nullable = false)
+    private Boolean publishing;
+
     @ManyToOne(optional = false)
     @JsonIdentityInfo(generator = ObjectIdGenerators.PropertyGenerator.class, scope = Project.class, resolver = ProjectByNameResolver.class, property = "name")
     @JsonIdentityReference(alwaysAsId = true)
@@ -57,6 +60,7 @@ public class Document extends BaseEntity {
     public Document() {
         fields = new ArrayList<MetadataFieldGroup>();
         publishedLocations = new ArrayList<PublishedLocation>();
+        publishing = false;
     }
 
     public Document(Project project, String name, String path, String status) {
@@ -168,6 +172,14 @@ public class Document extends BaseEntity {
             }
         }
         return targetField;
+    }
+
+    public Boolean isPublishing() {
+        return publishing;
+    }
+
+    public void isPublishing(Boolean publishing) {
+        this.publishing = publishing;
     }
 
 }

--- a/src/test/java/edu/tamu/app/controller/AbstractControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/AbstractControllerTest.java
@@ -58,7 +58,7 @@ public abstract class AbstractControllerTest extends MockData {
 
     @Mock
     protected DocumentRepo documentRepo;
-    
+
     @Mock
     protected ResourceRepo resourceRepo;
 
@@ -189,6 +189,13 @@ public abstract class AbstractControllerTest extends MockData {
             }
         });
 
+        when(documentRepo.findOne(any(Long.class))).then(new Answer<Document>() {
+            @Override
+            public Document answer(InvocationOnMock invocation) throws Throwable {
+                return findDocumentById((Long) invocation.getArguments()[0]);
+            }
+        });
+
         // TODO
         when(documentRepo.pageableDynamicDocumentQuery((Map<String, String[]>) any(Map.class), (org.springframework.data.domain.Pageable) any(Pageable.class))).then(new Answer<Page<Document>>() {
             @Override
@@ -202,7 +209,7 @@ public abstract class AbstractControllerTest extends MockData {
         // project
         when(projectRepo.findAll()).thenReturn(mockProjectList);
 
-        when(projectRepo.create(any(String.class), any(IngestType.class), any(Boolean.class), (List<ProjectRepository>) any(List.class), any(List.class), any(List.class))).then(new Answer<Project>() {
+        when(projectRepo.create(any(String.class), any(IngestType.class), any(Boolean.class), any(List.class), any(List.class), any(List.class))).then(new Answer<Project>() {
             @Override
             public Project answer(InvocationOnMock invocation) throws Throwable {
                 return TEST_PROJECT1;
@@ -250,7 +257,7 @@ public abstract class AbstractControllerTest extends MockData {
                 return TEST_PROJECT1;
             }
         });
-        
+
         // resource
         when(resourceRepo.findAllByDocumentProjectNameAndDocumentName(any(String.class), any(String.class))).thenReturn(new ArrayList<Resource>());
 

--- a/src/test/java/edu/tamu/app/controller/DocumentControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/DocumentControllerTest.java
@@ -48,6 +48,16 @@ public class DocumentControllerTest extends AbstractControllerTest {
         Document document = (Document) response.getPayload().get("Document");
         assertEquals(" The document has a different document name ", TEST_DOCUMENT1.getName(), document.getName());
         assertEquals(" The document has a different project name ", TEST_PROJECT1.getName(), document.getProject().getName());
+        assertEquals(" The document has isPublishing set to TRUE ", false, document.isPublishing());
+    }
+
+    @Test
+    public void testPushAlreadyPublishingDocument() {
+        response = documentController.push(TEST_DOCUMENT4.getProject().getName(), TEST_DOCUMENT4.getName());
+        assertEquals(" The response did not error ", ApiStatus.ERROR, response.getMeta().getStatus());
+        assertEquals(" The document did not error due to pending publications ", "Cannot publish because document is already pending publication", response.getMeta().getMessage());
+        Document document = documentRepo.findOne(TEST_DOCUMENT4.getId());
+        assertEquals(" The document has isPublishing set to FALSE ", true, document.isPublishing());
     }
 
     @Test

--- a/src/test/java/edu/tamu/app/controller/MockData.java
+++ b/src/test/java/edu/tamu/app/controller/MockData.java
@@ -111,15 +111,18 @@ public class MockData {
     protected static Document TEST_DOCUMENT1 = new Document(TEST_PROJECT1, "Doc1 name", "documentPath1", "Unassigned");
     protected static Document TEST_DOCUMENT2 = new Document(TEST_PROJECT1, "Doc2 name", "documentPath2", "Pending");
     protected static Document TEST_DOCUMENT3 = new Document(TEST_PROJECT1, "Doc3 name", "documentPath3", "Accepted");
+    protected static Document TEST_DOCUMENT4 = new Document(TEST_PROJECT1, "Doc4 name", "documentPath4", "Accepted");
 
     static {
         TEST_DOCUMENT1.setId(1l);
         TEST_DOCUMENT2.setId(2l);
         TEST_DOCUMENT3.setId(3l);
+        TEST_DOCUMENT4.setId(4l);
+        TEST_DOCUMENT4.isPublishing(true);
         TEST_DOCUMENT1.setProject(TEST_PROJECT1);
     }
 
-    protected static List<Document> mockDocumentList = new ArrayList<Document>(Arrays.asList(new Document[] { TEST_DOCUMENT1, TEST_DOCUMENT2, TEST_DOCUMENT3 }));
+    protected static List<Document> mockDocumentList = new ArrayList<Document>(Arrays.asList(new Document[] { TEST_DOCUMENT1, TEST_DOCUMENT2, TEST_DOCUMENT3, TEST_DOCUMENT4 }));
 
     public Document saveDocument(Document modifiedDocument) {
         Document returnDocument = null;
@@ -128,6 +131,7 @@ public class MockData {
                 document.setProject(modifiedDocument.getProject());
                 document.setName(modifiedDocument.getName());
                 document.setStatus(modifiedDocument.getStatus());
+                document.isPublishing(modifiedDocument.isPublishing());
                 returnDocument = document;
                 break;
             }
@@ -138,6 +142,15 @@ public class MockData {
     public Document findDocumentByProjectNameandName(String projectName, String documentName) {
         for (Document document : mockDocumentList) {
             if (document.getName().equals(documentName) && document.getProject().getName().equals(projectName)) {
+                return document;
+            }
+        }
+        return null;
+    }
+
+    public Document findDocumentById(Long documentId) {
+        for (Document document: mockDocumentList) {
+            if (document.getId().equals(documentId)) {
                 return document;
             }
         }


### PR DESCRIPTION
Provide a new property on the document model `publishing` to safely reflect the publishing state without interfering with existing utilization of the `status` property.

Updated tests appropriately

relates: TAMULib/MetadataAssignmentToolUI#141