### PR TITLE
[B03983] Broadcast last event to in-progress Publishing box - eliminate the spinner

### DIFF
--- a/src/main/java/edu/tamu/app/controller/DocumentController.java
+++ b/src/main/java/edu/tamu/app/controller/DocumentController.java
@@ -3,7 +3,6 @@ package edu.tamu.app.controller;
 import static edu.tamu.weaver.response.ApiStatus.ERROR;
 import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -179,7 +178,7 @@ public class DocumentController {
         for (ProjectRepository repository : document.getProject().getRepositories()) {
             try {
                 document = ((Destination) projectServiceRegistry.getService(repository.getName())).push(document);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 document.isPublishing(false);
                 documentRepo.update(document);
 

--- a/src/main/java/edu/tamu/app/model/PublishingEvent.java
+++ b/src/main/java/edu/tamu/app/model/PublishingEvent.java
@@ -1,0 +1,31 @@
+package edu.tamu.app.model;
+
+import java.util.Date;
+
+public class PublishingEvent {
+
+    private final PublishingType type;
+
+    private final String message;
+
+    private final Date timestamp;
+
+    public PublishingEvent(PublishingType type, String message) {
+        this.type = type;
+        this.message = message;
+        timestamp =  new Date(System.currentTimeMillis());
+    }
+
+    public PublishingType getType() {
+        return type;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+}

--- a/src/main/java/edu/tamu/app/model/PublishingType.java
+++ b/src/main/java/edu/tamu/app/model/PublishingType.java
@@ -1,0 +1,5 @@
+package edu.tamu.app.model;
+
+public enum PublishingType {
+    ALERT, ATTACHMENT, CONNECTION, ITEM, MESSAGE, WARNING
+}

--- a/src/main/java/edu/tamu/app/service/repository/PublishingRepository.java
+++ b/src/main/java/edu/tamu/app/service/repository/PublishingRepository.java
@@ -1,0 +1,26 @@
+package edu.tamu.app.service.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import edu.tamu.app.model.PublishingEvent;
+import edu.tamu.app.model.PublishingType;
+import edu.tamu.weaver.response.ApiAction;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.response.ApiStatus;
+
+public abstract class PublishingRepository implements Repository {
+
+    @Autowired
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    protected String getChannel() {
+        return "/channel/publishing";
+    }
+
+    protected void broadcastDocument(Long documentId, PublishingType type, String message) {
+        ApiResponse response = new ApiResponse(ApiStatus.SUCCESS, ApiAction.BROADCAST, new PublishingEvent(type, message));
+        simpMessagingTemplate.convertAndSend(getChannel() + "/document/" + documentId, response);
+    }
+
+}


### PR DESCRIPTION
Create publishing repository specific events.
Broadcast these events for the Dspace repository.

The broadcasting channel is implemented at "/channel/publishing" because "/channel/repository" seems a bit confusing due to there being conflicting meanings of "repo" in use.
The document channel is then at "/channel/publishing/document" to avoid id collisions for anything else that potentially may need use a publishing channel.

A PublishingType enum is implemented to give hints to the front-end on how to process and present specific events.
This PublishingType enum is implemented very generally to allow being used in other repositories, such as Fedora.

The Dspace Repository events are broadcast with detailed information.
The Repository being connected/disconnected to is specifically added to help ensure that when multiple repositories are used, the log will be less confusing.

There are some cases where the session is not closed, namely on Exceptions.
Ensure that the connection is closed and present the event log for the end of the session.

The isPublishing state should always be reset on exception.