### PR TITLE
[B03985][FIX] Preserve the PropertyProtectionService on project update

### DIFF
--- a/src/main/java/edu/tamu/app/controller/ProjectController.java
+++ b/src/main/java/edu/tamu/app/controller/ProjectController.java
@@ -40,6 +40,7 @@ import edu.tamu.app.model.repo.ProjectRepositoryRepo;
 import edu.tamu.app.model.repo.ProjectSuggestorRepo;
 import edu.tamu.app.model.repo.ResourceRepo;
 import edu.tamu.app.service.ProjectFactory;
+import edu.tamu.app.service.PropertyProtectionService;
 import edu.tamu.app.service.SyncService;
 import edu.tamu.app.service.registry.MagpieServiceRegistry;
 import edu.tamu.app.service.repository.Destination;
@@ -86,6 +87,9 @@ public class ProjectController {
     @Autowired
     private SyncService syncService;
 
+    @Autowired
+    private PropertyProtectionService propertyProtectionService;
+
     /**
      * Endpoint to return list of projects.
      *
@@ -127,17 +131,29 @@ public class ProjectController {
         });
         project.setRepositories(projectRepositoryRepo.findAll(projectRepositoryIds));
 
+        project.getRepositories().forEach(r -> {
+            r.setPropertyProtectionService(propertyProtectionService);
+        });
+
         List<Long> projectAuthorityIds = new ArrayList<Long>();
         project.getAuthorities().forEach(pa -> {
             projectAuthorityIds.add(pa.getId());
         });
         project.setAuthorities(projectAuthorityRepo.findAll(projectAuthorityIds));
 
+        project.getAuthorities().forEach(a -> {
+            a.setPropertyProtectionService(propertyProtectionService);
+        });
+
         List<Long> projectSuggestorIds = new ArrayList<Long>();
         project.getSuggestors().forEach(ps -> {
             projectSuggestorIds.add(ps.getId());
         });
         project.setSuggestors(projectSuggestorRepo.findAll(projectSuggestorIds));
+
+        project.getSuggestors().forEach(s -> {
+            s.setPropertyProtectionService(propertyProtectionService);
+        });
 
         BeanUtils.copyProperties(project, currentProject, "documents","profiles");
         currentProject = projectRepo.update(currentProject);

--- a/src/main/java/edu/tamu/app/model/repo/impl/ProjectAuthorityRepoImpl.java
+++ b/src/main/java/edu/tamu/app/model/repo/impl/ProjectAuthorityRepoImpl.java
@@ -30,7 +30,6 @@ public class ProjectAuthorityRepoImpl extends AbstractWeaverRepoImpl<ProjectAuth
 
     @Override
     public ProjectAuthority create(ProjectAuthority projectAuthority) {
-        projectAuthority.setPropertyProtectionService(propertyProtectionService);
         return super.create(processProjectAuthority(projectAuthority));
     }
 
@@ -45,7 +44,7 @@ public class ProjectAuthorityRepoImpl extends AbstractWeaverRepoImpl<ProjectAuth
         projectAuthority.setName(name);
         projectAuthority.setType(serviceType);
         projectAuthority.setSettings(settings);
-        return projectAuthorityRepo.create(projectAuthority);
+        return this.create(projectAuthority);
     }
 
     @Override
@@ -83,6 +82,7 @@ public class ProjectAuthorityRepoImpl extends AbstractWeaverRepoImpl<ProjectAuth
     }
 
     private ProjectAuthority processProjectAuthority(ProjectAuthority projectAuthority) {
+        projectAuthority.setPropertyProtectionService(propertyProtectionService);
         projectAuthority.getSettings().forEach(s -> {
             if (s.isProtect()) {
                 try {

--- a/src/main/java/edu/tamu/app/model/repo/impl/ProjectRepositoryRepoImpl.java
+++ b/src/main/java/edu/tamu/app/model/repo/impl/ProjectRepositoryRepoImpl.java
@@ -8,7 +8,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.tamu.app.model.Project;
-import edu.tamu.app.model.ProjectAuthority;
 import edu.tamu.app.model.ProjectRepository;
 import edu.tamu.app.model.ProjectSetting;
 import edu.tamu.app.model.ServiceType;
@@ -31,7 +30,6 @@ public class ProjectRepositoryRepoImpl extends AbstractWeaverRepoImpl<ProjectRep
 
     @Override
     public ProjectRepository create(ProjectRepository projectRepository) {
-        projectRepository.setPropertyProtectionService(propertyProtectionService);
         return super.create(processProjectRepository(projectRepository));
     }
 
@@ -46,7 +44,7 @@ public class ProjectRepositoryRepoImpl extends AbstractWeaverRepoImpl<ProjectRep
         projectRepository.setName(name);
         projectRepository.setType(serviceType);
         projectRepository.setSettings(settings);
-        return projectRepositoryRepo.create(projectRepository);
+        return this.create(projectRepository);
     }
 
     @Override
@@ -84,6 +82,7 @@ public class ProjectRepositoryRepoImpl extends AbstractWeaverRepoImpl<ProjectRep
     }
 
     private ProjectRepository processProjectRepository(ProjectRepository projectRepository) {
+        projectRepository.setPropertyProtectionService(propertyProtectionService);
         projectRepository.getSettings().forEach(s -> {
             if (s.isProtect()) {
                 try {

--- a/src/main/java/edu/tamu/app/model/repo/impl/ProjectSuggestorRepoImpl.java
+++ b/src/main/java/edu/tamu/app/model/repo/impl/ProjectSuggestorRepoImpl.java
@@ -30,7 +30,6 @@ public class ProjectSuggestorRepoImpl extends AbstractWeaverRepoImpl<ProjectSugg
 
     @Override
     public ProjectSuggestor create(ProjectSuggestor projectSuggestor) {
-        projectSuggestor.setPropertyProtectionService(propertyProtectionService);
         return super.create(processProjectSuggestor(projectSuggestor));
     }
 
@@ -45,7 +44,7 @@ public class ProjectSuggestorRepoImpl extends AbstractWeaverRepoImpl<ProjectSugg
         projectSuggestor.setName(name);
         projectSuggestor.setType(serviceType);
         projectSuggestor.setSettings(settings);
-        return projectSuggestorRepo.create(projectSuggestor);
+        return this.create(projectSuggestor);
     }
 
     @Override
@@ -83,6 +82,7 @@ public class ProjectSuggestorRepoImpl extends AbstractWeaverRepoImpl<ProjectSugg
     }
 
     private ProjectSuggestor processProjectSuggestor(ProjectSuggestor projectSuggestor) {
+        projectSuggestor.setPropertyProtectionService(propertyProtectionService);
         projectSuggestor.getSettings().forEach(s -> {
             if (s.isProtect()) {
                 try {

--- a/src/main/java/edu/tamu/app/service/ProjectFactory.java
+++ b/src/main/java/edu/tamu/app/service/ProjectFactory.java
@@ -98,9 +98,6 @@ public class ProjectFactory {
     private ProjectAuthorityRepo projectAuthorityRepo;
 
     @Autowired
-    PropertyProtectionService propertyProtectionService;
-
-    @Autowired
     private FieldProfileRepo fieldProfileRepo;
 
     @Autowired

--- a/src/main/java/edu/tamu/app/service/repository/DSpaceRepository.java
+++ b/src/main/java/edu/tamu/app/service/repository/DSpaceRepository.java
@@ -14,7 +14,6 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -54,13 +53,11 @@ import edu.tamu.app.model.Document;
 import edu.tamu.app.model.MetadataFieldGroup;
 import edu.tamu.app.model.MetadataFieldValue;
 import edu.tamu.app.model.ProjectRepository;
-import edu.tamu.app.model.ProjectSetting;
 import edu.tamu.app.model.PublishedLocation;
 import edu.tamu.app.model.PublishingType;
 import edu.tamu.app.model.Resource;
 import edu.tamu.app.model.repo.DocumentRepo;
 import edu.tamu.app.model.repo.ResourceRepo;
-import edu.tamu.app.service.PropertyProtectionService;
 
 public class DSpaceRepository extends PublishingRepository {
 
@@ -74,9 +71,6 @@ public class DSpaceRepository extends PublishingRepository {
 
     @Autowired
     private ResourceRepo resourceRepo;
-
-    @Autowired
-    private PropertyProtectionService propertyProtectionService;
 
     private ProjectRepository projectRepository;
 


### PR DESCRIPTION
The transient PropertyProtectionService can sometimes be lost when the project is updated. This PR explicitly sets the PPS on the ProjectServices when the project is updated.